### PR TITLE
Enable Assurance workflow

### DIFF
--- a/AEPMedia/Sources/Event+Media.swift
+++ b/AEPMedia/Sources/Event+Media.swift
@@ -18,11 +18,32 @@ extension Event {
         return data?[MediaConstants.Tracker.ID] as? String
     }
 
+    /// Returns client generated session id associated with Event
+    var sessionId: String? {
+        return data?[MediaConstants.Tracker.SESSION_ID] as? String
+    }
+
     /// Returns tracker config associated with EVENT_SOURCE_TRACKER_REQUEST Event
     var trackerConfig: [String: Any]? {
         guard source == MediaConstants.Media.EVENT_SOURCE_TRACKER_REQUEST else {
             return nil
         }
         return data?[MediaConstants.Tracker.EVENT_PARAM] as? [String: Any]
+    }
+
+    var param: [String: Any]? {
+        return data?[MediaConstants.Tracker.EVENT_PARAM] as? [String: Any]
+    }
+
+    var metadata: [String: String]? {
+        return data?[MediaConstants.Tracker.EVENT_METADATA] as? [String: String]
+    }
+
+    var name: String? {
+        return data?[MediaConstants.Tracker.EVENT_NAME] as? String
+    }
+
+    var eventTs: Int64? {
+        return data?[MediaConstants.Tracker.EVENT_TIMESTAMP] as? Int64
     }
 }

--- a/AEPMedia/Sources/Media.swift
+++ b/AEPMedia/Sources/Media.swift
@@ -36,7 +36,6 @@ public class Media: NSObject, Extension {
     /// Initializes the Media extension and it's dependencies
     public required init(runtime: ExtensionRuntime) {
         self.runtime = runtime
-
         let mediaHitsDatabase = MediaHitsDatabase(databaseName: MediaConstants.DATABASE_NAME)
         let mediaDBService = MediaDBService(mediaHitsDatabase: mediaHitsDatabase)
         self.mediaService = MediaService(mediaDBService: mediaDBService)
@@ -45,6 +44,8 @@ public class Media: NSObject, Extension {
 
     /// Invoked when the Media extension has been registered by the `EventHub`
     public func onRegistered() {
+        mediaService.readyToProcess(dispatchFn: dispathSessionCreated(eventData:))
+
         registerListener(type: EventType.configuration, source: EventSource.responseContent, listener: handleConfigurationResponseEvent)
         registerListener(type: MediaConstants.Media.EVENT_TYPE, source: MediaConstants.Media.EVENT_SOURCE_TRACKER_REQUEST, listener: handleMediaTrackerRequest)
         registerListener(type: MediaConstants.Media.EVENT_TYPE, source: MediaConstants.Media.EVENT_SOURCE_TRACK_MEDIA, listener: handleMediaTrack)
@@ -119,6 +120,14 @@ public class Media: NSObject, Extension {
             return
         }
 
-        tracker.track(eventData: event.data)
+        tracker.track(event: event)
+    }
+
+    private func dispathSessionCreated(eventData: [String: Any]) {
+        let event = Event(name: MediaConstants.Media.EVENT_NAME_SESSION_CREATED,
+                          type: MediaConstants.Media.EVENT_TYPE,
+                          source: MediaConstants.Media.EVENT_SOURCE_SESSION_CREATED,
+                          data: eventData)
+        dispatch(event: event)
     }
 }

--- a/AEPMedia/Sources/MediaCollection/MediaCollectionHitGenerator.swift
+++ b/AEPMedia/Sources/MediaCollection/MediaCollectionHitGenerator.swift
@@ -66,7 +66,7 @@ class MediaCollectionHitGenerator {
 
         params[Media.DOWNLOADED] = downloadedContent
 
-        // Debug Params to link client generaed session id with backend generated id.
+        // Debug Params to link client generated session id with backend generated id.
         params[MediaConstants.Tracker.SESSION_ID] = refEvent.sessionId
 
         if let channel = mediaConfig[MediaConstants.TrackerConfig.CHANNEL] as? String, !channel.isEmpty {

--- a/AEPMedia/Sources/MediaCollection/MediaCollectionHitGenerator.swift
+++ b/AEPMedia/Sources/MediaCollection/MediaCollectionHitGenerator.swift
@@ -11,6 +11,7 @@
 
 import Foundation
 import AEPServices
+import AEPCore
 
 class MediaCollectionHitGenerator {
     private static let LOG_TAG = MediaConstants.LOG_TAG
@@ -18,6 +19,7 @@ class MediaCollectionHitGenerator {
     private let mediaHitProcessor: MediaProcessor
     private let mediaConfig: [String: Any]
     private let downloadedContent: Bool
+    private let refEvent: Event
     private var lastReportedQoeData: [String: Any] = [:]
     private var isTracking: Bool = false
     private var reportingInterval: Int64
@@ -36,7 +38,7 @@ class MediaCollectionHitGenerator {
     #endif
 
     /// Initializes the Media Collection Hit Generator
-    public required init?(context: MediaContext?, hitProcessor: MediaProcessor, config: [String: Any], refTS: Int64) {
+    public required init?(context: MediaContext?, hitProcessor: MediaProcessor, config: [String: Any], refEvent: Event, refTS: Int64) {
         guard let context = context else {
             Log.debug(label: Self.LOG_TAG, "[\(Self.CLASS_NAME)<\(#function)>] - Unable to create a MediaCollectionHitGenerator, media context is nil.")
             return nil
@@ -44,6 +46,7 @@ class MediaCollectionHitGenerator {
         self.mediaContext = context
         self.mediaHitProcessor = hitProcessor
         self.mediaConfig = config
+        self.refEvent = refEvent
         self.refTS = refTS
         self.currentPlaybackState = .Init
         self.currentPlaybackStateStartRefTS = refTS
@@ -62,6 +65,9 @@ class MediaCollectionHitGenerator {
         }
 
         params[Media.DOWNLOADED] = downloadedContent
+
+        // Debug Params to link client generaed session id with backend generated id.
+        params[MediaConstants.Tracker.SESSION_ID] = refEvent.sessionId
 
         if let channel = mediaConfig[MediaConstants.TrackerConfig.CHANNEL] as? String, !channel.isEmpty {
             params[Media.CHANNEL] = channel

--- a/AEPMedia/Sources/MediaCollection/MediaCollectionReportHelper.swift
+++ b/AEPMedia/Sources/MediaCollection/MediaCollectionReportHelper.swift
@@ -178,6 +178,9 @@ class MediaCollectionReportHelper {
 
             params[MediaConstants.MediaCollection.Session.MEDIA_VERSION] = MediaConstants.MediaCollection.MEDIA_VERSION
 
+            // Remove debugParams from MediaHit
+            params.removeValue(forKey: MediaConstants.Tracker.SESSION_ID)
+
             return MediaHit(eventType: mediaHit.eventType, playhead: mediaHit.playhead, ts: mediaHit.timestamp, params: params, customMetadata: mediaHit.metadata, qoeData: mediaHit.qoeData)
 
         }
@@ -256,5 +259,22 @@ class MediaCollectionReportHelper {
             return String(data: data, encoding: .utf8)
         }
         return nil
+    }
+
+    static func extractDebugInfo(hit: MediaHit) -> [String: Any] {
+        var ret = [String: Any]()
+        if hit.eventType == MediaConstants.MediaCollection.EventType.SESSION_START {
+            ret[MediaConstants.Tracker.SESSION_ID] = hit.params?[MediaConstants.Tracker.SESSION_ID] as? String
+        }
+        return ret
+    }
+
+    static func extractDebugInfo(hits: [MediaHit]) -> [String: Any] {
+        let hit = hits.first { hit in return hit.eventType == MediaConstants.MediaCollection.EventType.SESSION_START }
+        if let hit = hit {
+            return extractDebugInfo(hit: hit)
+        } else {
+            return [String: Any]()
+        }
     }
 }

--- a/AEPMedia/Sources/MediaCollection/MediaOfflineSession.swift
+++ b/AEPMedia/Sources/MediaCollection/MediaOfflineSession.swift
@@ -102,7 +102,7 @@ class MediaOfflineSession: MediaSession {
         isReportingSession = true
 
         let httpHeaders = MediaConstants.Networking.REQUEST_HEADERS
-        // Disable sending assuracne integration id till backend returns generated session id.
+        // Disable sending assurance integration id till backend returns generated session id.
         // if let assuranceIntegrationId = state.assuranceIntegrationId {
         //    httpHeaders[MediaConstants.Networking.HEADER_KEY_AEP_VALIDATION_TOKEN] = assuranceIntegrationId
         // }

--- a/AEPMedia/Sources/MediaCollection/MediaOfflineSession.swift
+++ b/AEPMedia/Sources/MediaCollection/MediaOfflineSession.swift
@@ -101,10 +101,11 @@ class MediaOfflineSession: MediaSession {
 
         isReportingSession = true
 
-        var httpHeaders = MediaConstants.Networking.REQUEST_HEADERS
-        if let assuranceIntegrationId = state.assuranceIntegrationId {
-            httpHeaders[MediaConstants.Networking.HEADER_KEY_AEP_VALIDATION_TOKEN] = assuranceIntegrationId
-        }
+        let httpHeaders = MediaConstants.Networking.REQUEST_HEADERS
+        // Disable sending assuracne integration id till backend returns generated session id.
+        // if let assuranceIntegrationId = state.assuranceIntegrationId {
+        //    httpHeaders[MediaConstants.Networking.HEADER_KEY_AEP_VALIDATION_TOKEN] = assuranceIntegrationId
+        // }
 
         let networkRequest = NetworkRequest(url: url,
                                             httpMethod: .post,

--- a/AEPMedia/Sources/MediaCollection/MediaOfflineSession.swift
+++ b/AEPMedia/Sources/MediaCollection/MediaOfflineSession.swift
@@ -30,9 +30,10 @@ class MediaOfflineSession: MediaSession {
     ///    - state: `MediaState` object
     ///    - dispatchQueue: `DispatchQueue` used for handling response after processing `MediaHit`    
     ///    - mediaDBService: `MediaDBService` object used for persisting hits in the database
-    init(id: String, state: MediaState, dispatchQueue: DispatchQueue, mediaDBService: MediaDBService) {
+    ///    - dispathFn: a function which when invoked dispatches sessionCreated Event
+    init(id: String, state: MediaState, dispatchQueue: DispatchQueue, mediaDBService: MediaDBService, dispathFn: (([String: Any]) -> Void)?) {
         self.mediaDBService = mediaDBService
-        super.init(id: id, state: state, dispatchQueue: dispatchQueue)
+        super.init(id: id, state: state, dispatchQueue: dispatchQueue, dispathFn: dispathFn)
     }
 
     override func handleQueueMediaHit(hit: MediaHit) {
@@ -100,7 +101,17 @@ class MediaOfflineSession: MediaSession {
 
         isReportingSession = true
 
-        let networkRequest = NetworkRequest(url: url, httpMethod: .post, connectPayload: body, httpHeaders: MediaConstants.Networking.REQUEST_HEADERS, connectTimeout: MediaConstants.Networking.HTTP_TIMEOUT_SECONDS, readTimeout: MediaConstants.Networking.HTTP_TIMEOUT_SECONDS)
+        var httpHeaders = MediaConstants.Networking.REQUEST_HEADERS
+        if let assuranceIntegrationId = state.assuranceIntegrationId {
+            httpHeaders[MediaConstants.Networking.HEADER_KEY_AEP_VALIDATION_TOKEN] = assuranceIntegrationId
+        }
+
+        let networkRequest = NetworkRequest(url: url,
+                                            httpMethod: .post,
+                                            connectPayload: body,
+                                            httpHeaders: httpHeaders,
+                                            connectTimeout: MediaConstants.Networking.HTTP_TIMEOUT_SECONDS,
+                                            readTimeout: MediaConstants.Networking.HTTP_TIMEOUT_SECONDS)
 
         ServiceProvider.shared.networkService.connectAsync(networkRequest: networkRequest) {[weak self] connection in
             self?.dispatchQueue.async {
@@ -119,6 +130,7 @@ class MediaOfflineSession: MediaSession {
                 Log.trace(label: Self.LOG_TAG, "[\(Self.CLASS_NAME)<\(#function)>] - [Session (\(self.id))] Network Request completed with status code: (\(statusCode)).")
 
                 if MediaConstants.Networking.HTTP_SUCCESS_RANGE.contains(statusCode) {
+                    // Todo :- Once backend returns session id, we should call the dispatch function
                     self.onSessionReportSuccess()
                 } else {
                     self.onSessionReportFailure()

--- a/AEPMedia/Sources/MediaCollection/MediaSession.swift
+++ b/AEPMedia/Sources/MediaCollection/MediaSession.swift
@@ -19,7 +19,7 @@ class MediaSession {
     let id: String
     let state: MediaState
     let dispatchQueue: DispatchQueue
-
+    let dispathFn: (([String: Any]) -> Void)?
     var isSessionActive: Bool
     var sessionEndHandler: (() -> Void)?
 
@@ -28,10 +28,12 @@ class MediaSession {
     ///    - id: Unique `MediaSession id`
     ///    - mediaState: `MediaState` object
     ///    - dispatchQueue: `DispatchQueue` used for handling response after processing `MediaHit`
-    init(id: String, state: MediaState, dispatchQueue: DispatchQueue) {
+    ///    - dispathFn: a function which when invoked dispatches sessionCreated Event
+    init(id: String, state: MediaState, dispatchQueue: DispatchQueue, dispathFn: (([String: Any]) -> Void)?) {
         self.id = id
         self.state = state
         self.dispatchQueue = dispatchQueue
+        self.dispathFn = dispathFn
         isSessionActive = true
     }
 

--- a/AEPMedia/Sources/MediaConstants.swift
+++ b/AEPMedia/Sources/MediaConstants.swift
@@ -26,6 +26,7 @@ internal extension MediaConstants {
         static let HTTP_TIMEOUT_SECONDS: TimeInterval = 5
         static let HTTP_SUCCESS_RANGE = 200..<300
         static let REQUEST_HEADERS = ["Content-type": "application/json"]
+        static let HEADER_KEY_AEP_VALIDATION_TOKEN = "X-Adobe-AEP-Validation-Token"
         static let INVALID_RESPONSE = -1
     }
 
@@ -58,13 +59,20 @@ internal extension MediaConstants {
         static let ANALYTICS_VISITOR_ID = "aid"
     }
 
+    enum Assurance {
+        static let SHARED_STATE_NAME = "com.adobe.assurance"
+        static let INTEGRATION_ID = "integrationid"
+    }
+
     enum Media {
         static let EVENT_TYPE = "com.adobe.eventtype.media"
         static let EVENT_SOURCE_TRACKER_REQUEST = "com.adobe.eventsource.media.requesttracker"
         static let EVENT_SOURCE_TRACKER_RESPONSE = "com.adobe.eventsource.media.responsetracker"
         static let EVENT_SOURCE_TRACK_MEDIA = "com.adobe.eventsource.media.trackmedia"
+        static let EVENT_SOURCE_SESSION_CREATED = "com.adobe.eventsource.media.sessioncreated"
         static let EVENT_NAME_CREATE_TRACKER = "Media::CreateTrackerRequest"
         static let EVENT_NAME_TRACK_MEDIA = "Media::TrackMedia"
+        static let EVENT_NAME_SESSION_CREATED = "Media::SessionCreated"
     }
 
     enum MediaConfig {
@@ -155,6 +163,7 @@ internal extension MediaConstants {
         static let EVENT_TIMESTAMP = "event.timestamp"
         static let EVENT_INTERNAL = "event.internal"
         static let PLAYHEAD = "time.playhead"
+        static let BACKEND_SESSION_ID = "mediaservice.sessionid"
     }
 
     enum PingInterval {

--- a/AEPMedia/Sources/MediaEventTracker.swift
+++ b/AEPMedia/Sources/MediaEventTracker.swift
@@ -499,7 +499,7 @@ class MediaEventTracker: MediaEventTracking {
     // MARK: Rule Actions
     private func cmdEnterAction(rule: MediaRule, context: [String: Any]) -> Bool {
         if hitGenerator != nil {
-            hitGenerator?.setRefTS(ts: getRefTS(context: context))//, event: context[Self.KEY_EVENT])
+            hitGenerator?.setRefTS(ts: getRefTS(context: context))
         }
         return true
     }

--- a/AEPMedia/Sources/MediaEventTracker.swift
+++ b/AEPMedia/Sources/MediaEventTracker.swift
@@ -11,6 +11,7 @@
 
 import Foundation
 import AEPServices
+import AEPCore
 
 class MediaEventTracker: MediaEventTracking {
     // MARK: Rule Name
@@ -101,6 +102,7 @@ class MediaEventTracker: MediaEventTracking {
     private static let KEY_INFO = "key_info"
     private static let KEY_METADATA = "key_metadata"
     private static let KEY_EVENT_TS = "key_eventts"
+    private static let KEY_EVENT = "key_event"
 
     private static let LOG_TAG = MediaConstants.LOG_TAG
     private static let CLASS_NAME = "MediaEventTracker"
@@ -158,39 +160,32 @@ class MediaEventTracker: MediaEventTracking {
     ///- Parameters:
     ///    - eventData: EventData for the track API consisting of eventName, playhead, timeStamp, params and metadata.
     @discardableResult
-    func track(eventData: [String: Any]?) -> Bool {
-        guard let eventData = eventData else {
-            Log.debug(label: Self.LOG_TAG, "[\(Self.CLASS_NAME)<\(#function)>] - Failed to track event (event data was null).")
+    func track(event: Event) -> Bool {
+
+        guard let rule = Self.eventToRuleMap[event.name ?? ""] else {
+            Log.debug(label: Self.LOG_TAG, "[\(Self.CLASS_NAME)<\(#function)>] - Event name is missing/invalid in track event data.")
             return false
         }
 
-        guard let eventName = eventData[MediaConstants.Tracker.EVENT_NAME] as? String else {
-            Log.debug(label: Self.LOG_TAG, "[\(Self.CLASS_NAME)<\(#function)>] - Event name is missing in track event data.")
-            return false
-        }
-
-        guard let rule = Self.eventToRuleMap[eventName] else {
-            Log.debug(label: Self.LOG_TAG, "[\(Self.CLASS_NAME)<\(#function)>] - Event name is invalid in track event data.")
-            return false
-        }
-
-        guard let eventTs = eventData[MediaConstants.Tracker.EVENT_TIMESTAMP] else {
+        guard let eventTs = event.eventTs else {
             Log.debug(label: Self.LOG_TAG, "[\(Self.CLASS_NAME)<\(#function)>] - Event timestamp is missing in track event data.")
             return false
         }
+
         var ruleContext: [String: Any] = [:]
+        ruleContext[Self.KEY_EVENT] = event
         ruleContext[Self.KEY_EVENT_TS] = eventTs
 
-        if let eventParam = eventData[MediaConstants.Tracker.EVENT_PARAM] {
-            ruleContext[Self.KEY_INFO] = eventParam
+        if let param = event.param {
+            ruleContext[Self.KEY_INFO] = param
         }
 
-        if let eventMetadata = eventData[MediaConstants.Tracker.EVENT_METADATA] as? [String: String] {
-            ruleContext[Self.KEY_METADATA] = cleanMetadata(data: eventMetadata)
+        if let metadata = event.metadata {
+            ruleContext[Self.KEY_METADATA] = cleanMetadata(data: metadata)
         }
 
         if rule != RuleName.PlayheadUpdate {
-            Log.trace(label: Self.LOG_TAG, "[\(Self.CLASS_NAME)<\(#function)>] - Processing event - \(eventName)")
+            Log.trace(label: Self.LOG_TAG, "[\(Self.CLASS_NAME)<\(#function)>] - Processing event - \(String(describing: event.name))")
         }
 
         if prerollDeferRule(rule: rule, context: ruleContext) {
@@ -504,7 +499,7 @@ class MediaEventTracker: MediaEventTracking {
     // MARK: Rule Actions
     private func cmdEnterAction(rule: MediaRule, context: [String: Any]) -> Bool {
         if hitGenerator != nil {
-            hitGenerator?.setRefTS(ts: getRefTS(context: context))
+            hitGenerator?.setRefTS(ts: getRefTS(context: context))//, event: context[Self.KEY_EVENT])
         }
         return true
     }
@@ -549,12 +544,16 @@ class MediaEventTracker: MediaEventTracking {
             return false
         }
 
+        guard let refEvent = context[Self.KEY_EVENT] as? Event else {
+            return false
+        }
+
         let metadata = getMetadata(context: context)
 
         let refTS = getRefTS(context: context)
 
         mediaContext = MediaContext(mediaInfo: mediaInfo, metadata: metadata)
-        hitGenerator = MediaCollectionHitGenerator(context: mediaContext, hitProcessor: hitProcessor, config: config ?? [:], refTS: refTS)
+        hitGenerator = MediaCollectionHitGenerator(context: mediaContext, hitProcessor: hitProcessor, config: config ?? [:], refEvent: refEvent, refTS: refTS)
         hitGenerator?.processMediaStart()
 
         inPrerollInterval = mediaInfo.prerollWaitingTime != 0

--- a/AEPMedia/Sources/MediaEventTracker.swift
+++ b/AEPMedia/Sources/MediaEventTracker.swift
@@ -158,7 +158,7 @@ class MediaEventTracker: MediaEventTracking {
 
     /// Handles all the track API calls.
     ///- Parameters:
-    ///    - eventData: EventData for the track API consisting of eventName, playhead, timeStamp, params and metadata.
+    ///    - event: Event for the track API consisting of eventName, playhead, timeStamp, params and metadata.
     @discardableResult
     func track(event: Event) -> Bool {
 

--- a/AEPMedia/Sources/MediaEventTracking.swift
+++ b/AEPMedia/Sources/MediaEventTracking.swift
@@ -9,9 +9,10 @@
  governing permissions and limitations under the License.
  */
 import Foundation
+import AEPCore
 
 protocol MediaEventTracking {
 
     @discardableResult
-    func track(eventData: [String: Any]?) -> Bool
+    func track(event: Event) -> Bool
 }

--- a/AEPMedia/Sources/MediaHit.swift
+++ b/AEPMedia/Sources/MediaHit.swift
@@ -11,24 +11,25 @@
 
 import Foundation
 import AEPServices
+import AEPCore
 
 struct MediaHit: Codable {
-    /// Media Analytics Tracking Event Type
+    /// Media Hit type
     private (set) var eventType: String
 
-    /// Media Analytics parameters
+    /// Media Hit parameters
     private (set) var params: [String: Any]?
 
-    /// Media Analytics metadata
+    /// Media Hit metadata
     private (set) var metadata: [String: String]?
 
-    /// Media Analytics QoE data
+    /// Media Hit QoE data
     private (set) var qoeData: [String: Any]?
 
-    /// The current playhead
+    /// Media Hit playhead
     private (set) var playhead: Double = 0
 
-    /// The current timestamps
+    /// Media Hit timestamp
     private (set) var timestamp: Int64 = 0
 
     enum CodingKeys: String, CodingKey {

--- a/AEPMedia/Sources/MediaState.swift
+++ b/AEPMedia/Sources/MediaState.swift
@@ -42,6 +42,9 @@ class MediaState {
     private(set) var blob: String?
     private(set) var visitorCustomerIDs: [[String: Any]]?
 
+    // Assurance State
+    private(set) var assuranceIntegrationId: String?
+
     /// Takes the shared states map and updates the data within the Media State.
     /// - Parameter dataMap: The map contains the shared state data required by the Analytics SDK.
     func update(dataMap: [String: [String: Any]?]) {
@@ -56,6 +59,8 @@ class MediaState {
                 extractIdentityInfo(from: sharedState)
             case MediaConstants.Analytics.SHARED_STATE_NAME:
                 extractAnalyticsInfo(from: sharedState)
+            case MediaConstants.Assurance.SHARED_STATE_NAME:
+                extractAssuranceInfo(from: sharedState)
             default:
                 break
             }
@@ -104,5 +109,15 @@ class MediaState {
         }
         self.aid = analyticsData[MediaConstants.Analytics.ANALYTICS_VISITOR_ID] as? String
         self.vid = analyticsData[MediaConstants.Analytics.VISITOR_ID] as? String
+    }
+
+    /// Extracts the assurance data from the provided shared state data.
+    /// - Parameter assuranceData the data map from `Analytics` shared state.
+    func extractAssuranceInfo(from assuranceData: [String: Any]?) {
+        guard let assuranceData = assuranceData else {
+            Log.trace(label: Self.LOG_TAG, "[\(Self.CLASS_NAME)<\(#function)>] - Failed to extract assurance data (event data was nil).")
+            return
+        }
+        self.assuranceIntegrationId = assuranceData[MediaConstants.Assurance.INTEGRATION_ID] as? String
     }
 }

--- a/AEPMedia/Tests/FunctionalTests/OfflineFunctionalTests.swift
+++ b/AEPMedia/Tests/FunctionalTests/OfflineFunctionalTests.swift
@@ -27,7 +27,6 @@ class OfflineFunctionalTests: MediaFunctionalTestBase {
         super.setupBase()
         mockMediaData = MockMediaData()
         dispatchQueue = DispatchQueue(label: "testOfflineTime")
-
         mediaState = mockMediaData.mediaState
         mediaState.extractConfigurationInfo(from: mockMediaData.configSharedState)
         mediaState.extractIdentityInfo(from: mockMediaData.identitySharedState)
@@ -35,7 +34,7 @@ class OfflineFunctionalTests: MediaFunctionalTestBase {
 
         let mediaHitsDatabase = MediaHitsDatabase(databaseName: "test")
         mediaDBService = MediaDBService(mediaHitsDatabase: mediaHitsDatabase)
-        session = MediaOfflineSession(id: "sessionID", state: mediaState, dispatchQueue: dispatchQueue, mediaDBService: mediaDBService)
+        session = MediaOfflineSession(id: "sessionID", state: mediaState, dispatchQueue: dispatchQueue, mediaDBService: mediaDBService, dispathFn: { (_: [String: Any]) in })
         session.retryDuration = 0
     }
 

--- a/AEPMedia/Tests/FunctionalTests/Scenarios/BaseScenarioTest.swift
+++ b/AEPMedia/Tests/FunctionalTests/Scenarios/BaseScenarioTest.swift
@@ -42,14 +42,24 @@ class BaseScenarioTest: XCTestCase {
             XCTAssertEqual(expectedHits.count, actualHitIndexList.count, "No of expected hits (\(expectedHits.count)) not equal to actual hits (\(actualHitIndexList.count))")
 
             for i in 0...expectedHits.count-1 {
-                XCTAssertEqual(expectedHits[i], fakeMediaService.getHit(sessionId: sessionId, index: actualHitIndexList[i]))
+                XCTAssertEqual(expectedHits[i], processHit(fakeMediaService.getHit(sessionId: sessionId, index: actualHitIndexList[i])))
             }
         } else {
             let actualHitsCount = fakeMediaService.getHitCount(sessionId: sessionId)
             XCTAssertEqual(expectedHits.count, actualHitsCount, "No of expected hits (\(expectedHits.count)) not equal to actual hits (\(actualHitsCount))")
             for i in 0...expectedHits.count-1 {
-                XCTAssertEqual(expectedHits[i], fakeMediaService.getHit(sessionId: sessionId, index: i))
+                XCTAssertEqual(expectedHits[i], processHit(fakeMediaService.getHit(sessionId: sessionId, index: i)))
             }
         }
+    }
+
+    func processHit(_ mediaHit: MediaHit?) -> MediaHit? {
+        // If sessionStart, check if present and remove client session id from the hit.
+        guard let hit = mediaHit, hit.eventType == MediaConstants.MediaCollection.EventType.SESSION_START else { return mediaHit }
+
+        XCTAssertTrue(hit.params?.keys.contains(MediaConstants.Tracker.SESSION_ID) ?? false)
+        var params = hit.params
+        params?.removeValue(forKey: MediaConstants.Tracker.SESSION_ID)
+        return MediaHit(eventType: hit.eventType, playhead: hit.playhead, ts: hit.timestamp, params: params, customMetadata: hit.metadata, qoeData: hit.qoeData)
     }
 }

--- a/AEPMedia/Tests/TestHelpers/FakeMediaEventTracker.swift
+++ b/AEPMedia/Tests/TestHelpers/FakeMediaEventTracker.swift
@@ -12,13 +12,14 @@
 
 import Foundation
 import AEPServices
+import AEPCore
 @testable import AEPMedia
 
 class FakeMediaEventTracker: MediaEventTracker {
 
     var trackCalled = false
 
-    override func track(eventData: [String: Any]?) -> Bool {
+    override func track(event: Event) -> Bool {
         trackCalled = true
         return trackCalled
     }

--- a/AEPMedia/Tests/TestHelpers/MediaEventGenerator.swift
+++ b/AEPMedia/Tests/TestHelpers/MediaEventGenerator.swift
@@ -130,7 +130,10 @@ class MediaEventGenerator: MediaTracker {
     private func waitForTrackerRequest() {
         if !usingProvidedDispatchFn {
             semaphore.wait()
-            coreEventTracker?.track(eventData: dispatchedEvent?.data)
+            if let dispatchedEvent = dispatchedEvent {
+                coreEventTracker?.track(event: dispatchedEvent)
+            }
+
         }
     }
 }

--- a/AEPMedia/Tests/TestHelpers/MockMediaData.swift
+++ b/AEPMedia/Tests/TestHelpers/MockMediaData.swift
@@ -21,14 +21,18 @@ class MockMediaData {
     var configSharedStateOptOut: [String: Any]!
     var configSharedStateUnknown: [String: Any]!
     var configSharedStateOptIn: [String: Any]!
+    var assuranceSharedState: [String: Any]!
+    var assuranceIntegrationId: String!
 
     var mediaState: MediaState!
     var mediaStateEmpty: MediaState!
     var mediaStateLocHintException: MediaState!
 
+    var sessionStartClientSessionId: String!
     var sessionStart: MediaHit!
     var sessionStartJson: String!
     var sessionStartJsonWithState: String!
+    var sessionStartWithSessionId: MediaHit!
     var session_start_json_with_configuration_identity_state: String!
 
     var sessionStartChannel: MediaHit!
@@ -102,6 +106,12 @@ class MockMediaData {
             MediaConstants.Analytics.ANALYTICS_VISITOR_ID: "aid"
         ]
 
+        // assurance shared state
+        assuranceIntegrationId = "assurance_token"
+        assuranceSharedState = [
+            MediaConstants.Assurance.INTEGRATION_ID: assuranceIntegrationId as Any
+        ]
+
         //setup Media State
         var sharedState = [String: [String: Any]]()
         sharedState[MediaConstants.Configuration.SHARED_STATE_NAME] = configSharedState
@@ -119,6 +129,8 @@ class MockMediaData {
 
         //Session Start
 
+        sessionStartClientSessionId = "clientSessionId"
+
         var params = [String: Any]()
         params["media.name"] = "media_name"
         params["media.id"] = "media_id"
@@ -127,6 +139,7 @@ class MockMediaData {
         params["media.length"] = 1800
         params["media.resume"] = false
         params["media.downloaded"] = true
+        params["sessionid"] = sessionStartClientSessionId
 
         var metadata = [String: String]()
         metadata["key1"] = "value1"

--- a/AEPMedia/Tests/TestHelpers/MockMediaSession.swift
+++ b/AEPMedia/Tests/TestHelpers/MockMediaSession.swift
@@ -20,8 +20,8 @@ class MockMediaSession: MediaSession {
     var hasSessionEndCalled = false
     var hasSesionAbortCalled = false
 
-    override init(id: String, state: MediaState, dispatchQueue: DispatchQueue) {
-        super.init(id: id, state: state, dispatchQueue: dispatchQueue)
+    init(id: String, state: MediaState, dispatchQueue: DispatchQueue) {
+        super.init(id: id, state: state, dispatchQueue: dispatchQueue, dispathFn: nil)
     }
 
     override func handleSessionEnd() {

--- a/AEPMedia/Tests/UnitTests/MediaEventTrackerTests.swift
+++ b/AEPMedia/Tests/UnitTests/MediaEventTrackerTests.swift
@@ -67,7 +67,7 @@ class MediaEventTrackerTests: XCTestCase {
             return false
         }
 
-        return mediaTracker.track(eventData: event.data)
+        return mediaTracker.track(event: event)
     }
 
     func compareRuleNames(list1: [(name: RuleName, context: [String: Any])], list2:[(name: RuleName, context: [String: Any])]) -> Bool {
@@ -93,38 +93,42 @@ class MediaEventTrackerTests: XCTestCase {
     }
 
     // MARK: MediaEventTracker Unit Tests
-    func testTrackeventHandleAbsentEventData() {
-        XCTAssertFalse(mediaTracker.track(eventData: nil))
-    }
-
     func testTrackeventHandleAbsentEventName() {
         eventGenerator.trackSessionStart(info: Self.media!.toMap(), metadata: Self.metadata)
-
-        let event = eventGenerator.dispatchedEvent
-        var eventData = event?.data
+        var eventData = eventGenerator.dispatchedEvent?.data
         eventData?.removeValue(forKey: MediaConstants.Tracker.EVENT_NAME)
 
-        XCTAssertFalse(mediaTracker.track(eventData: eventData))
+        let event = Event(name: "",
+                          type: MediaConstants.Media.EVENT_TYPE,
+                          source: MediaConstants.Media.EVENT_NAME_TRACK_MEDIA,
+                          data: eventData)
+        XCTAssertFalse(mediaTracker.track(event: event))
     }
 
     func testTrackeventHandleIncorrectEventName() {
         eventGenerator.trackSessionStart(info: Self.media!.toMap(), metadata: Self.metadata)
 
-        let event = eventGenerator.dispatchedEvent
-        var eventData = event?.data
+        var eventData = eventGenerator.dispatchedEvent?.data
         eventData?[MediaConstants.Tracker.EVENT_NAME] = "incorrect"
 
-        XCTAssertFalse(mediaTracker.track(eventData: eventData))
+        let event = Event(name: "",
+                          type: MediaConstants.Media.EVENT_TYPE,
+                          source: MediaConstants.Media.EVENT_NAME_TRACK_MEDIA,
+                          data: eventData)
+        XCTAssertFalse(mediaTracker.track(event: event))
     }
 
     func testTrackeventHandleAbsentEventTimeStamp() {
         eventGenerator.trackSessionStart(info: Self.media!.toMap(), metadata: Self.metadata)
 
-        let event = eventGenerator.dispatchedEvent
-        var eventData = event?.data
+        var eventData = eventGenerator.dispatchedEvent?.data
         eventData?.removeValue(forKey: MediaConstants.Tracker.EVENT_TIMESTAMP)
 
-        XCTAssertFalse(mediaTracker.track(eventData: eventData))
+        let event = Event(name: "",
+                          type: MediaConstants.Media.EVENT_TYPE,
+                          source: MediaConstants.Media.EVENT_NAME_TRACK_MEDIA,
+                          data: eventData)
+        XCTAssertFalse(mediaTracker.track(event: event))
     }
 
     func testTrackSessionStartFailOtherAPIsBeforeStart() {

--- a/AEPMedia/Tests/UnitTests/MediaServiceTest.swift
+++ b/AEPMedia/Tests/UnitTests/MediaServiceTest.swift
@@ -23,7 +23,8 @@ class MediaServiceTest: XCTestCase {
         mockDBService.persistedSessionIds = persistedSessionIds
 
         //Action
-        _ = MediaService(mediaDBService: mockDBService)
+        let mediaService = MediaService(mediaDBService: mockDBService)
+        mediaService.readyToProcess(dispatchFn: {_ in })
         Thread.sleep(forTimeInterval: 0.25)
 
         //Assert


### PR DESCRIPTION
Enable Assurance debugging workflow for realtime sessions. 
If Assurance shared state is available, send `X-Adobe-AEP-Validation-Token` header in http requests.
Dispatch sessionCreated event with both client and backend generated session id for Griffon to link media metrics with API calls. 

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
