### PR TITLE
Fix the issue to allow trackingServer to have path /va for first party domains(tracking server)

### DIFF
--- a/AEPMedia/Sources/MediaCollection/MediaCollectionReportHelper.swift
+++ b/AEPMedia/Sources/MediaCollection/MediaCollectionReportHelper.swift
@@ -21,7 +21,7 @@ class MediaCollectionReportHelper {
     private init() {}
 
     /// Returns the `URL` for session start. The response contains the `sessionId`
-    /// - Parameter host: The tracking server url host component
+    /// - Parameter trackingServer: backend server domain
     /// - Returns: Session start request URL
     static func getTrackingURL(trackingServer: String) -> URL? {
         guard !trackingServer.isEmpty else {
@@ -40,7 +40,7 @@ class MediaCollectionReportHelper {
 
     /// Returns the URL for sending `MediaHits`
     /// - Parameters:
-    /// - host: Host component of the URL
+    /// - trackingServer: backend server domain
     /// - sessionId: the session id of the Media session
     /// - Returns: URL for sending media hits
     static func getTrackingURLForEvents(trackingServer: String, sessionId: String?) -> URL? {

--- a/AEPMedia/Sources/MediaCollection/MediaCollectionReportHelper.swift
+++ b/AEPMedia/Sources/MediaCollection/MediaCollectionReportHelper.swift
@@ -59,17 +59,9 @@ class MediaCollectionReportHelper {
     }
 
     static func getHostAndPath(_ trackingServer: String) -> (String, String) {
-        let trackingServerComponents = trackingServer.components(separatedBy: "/")
-
-        let host = trackingServerComponents[0]
-
-        var path = ""
-        if trackingServerComponents.count > 1 {
-            for i in 1...trackingServerComponents.count-1 {
-                path += "/" + trackingServerComponents[i]
-            }
-        }
-
+        var components = trackingServer.components(separatedBy: "/")
+        let host = components.removeFirst()
+        let path = components.isEmpty ? "" : "/" + components.joined(separator: "/")
         return (host: host, path: path)
     }
 

--- a/AEPMedia/Sources/MediaCollection/MediaCollectionReportHelper.swift
+++ b/AEPMedia/Sources/MediaCollection/MediaCollectionReportHelper.swift
@@ -29,12 +29,12 @@ class MediaCollectionReportHelper {
             return nil
         }
 
-        let serverAddress = getHostAndPath(trackingServer)
+        let (host, path) = getHostAndPath(trackingServer)
 
         var urlcomponents = URLComponents()
         urlcomponents.scheme = "https"
-        urlcomponents.host = serverAddress["host"]
-        urlcomponents.path = (serverAddress["path"] ?? "") + "/api/v1/sessions"
+        urlcomponents.host = host
+        urlcomponents.path = path + "/api/v1/sessions"
         return urlcomponents.url
     }
 
@@ -49,20 +49,19 @@ class MediaCollectionReportHelper {
             return nil
         }
 
-        let serverAddress = getHostAndPath(trackingServer)
+        let (host, path) = getHostAndPath(trackingServer)
 
         var urlComponents = URLComponents()
         urlComponents.scheme = "https"
-        urlComponents.host = serverAddress["host"]
-        urlComponents.path = (serverAddress["path"] ?? "") + "/api/v1/sessions/\(sessionId)/events"
+        urlComponents.host = host
+        urlComponents.path = path + "/api/v1/sessions/\(sessionId)/events"
         return urlComponents.url
     }
 
-    static func getHostAndPath(_ trackingServer: String) -> [String: String] {
-        var ret =  [String: String]()
+    static func getHostAndPath(_ trackingServer: String) -> (String, String) {
         let trackingServerComponents = trackingServer.components(separatedBy: "/")
 
-        ret["host"] = trackingServerComponents[0]
+        let host = trackingServerComponents[0]
 
         var path = ""
         if trackingServerComponents.count > 1 {
@@ -71,9 +70,7 @@ class MediaCollectionReportHelper {
             }
         }
 
-        ret["path"] = path
-
-        return ret
+        return (host: host, path: path)
     }
 
     /// Generates the payload for `MediaHit` in `MediaRealTimeSession`

--- a/AEPMedia/Sources/MediaCollection/MediaCollectionReportHelper.swift
+++ b/AEPMedia/Sources/MediaCollection/MediaCollectionReportHelper.swift
@@ -58,7 +58,10 @@ class MediaCollectionReportHelper {
         return urlComponents.url
     }
 
-    static func getHostAndPath(_ trackingServer: String) -> (String, String) {
+    /// Extracts domain and path from the input server address
+    /// - Parameter trackingServer: backend server domain, which contains path if it's a first party domain
+    /// - Returns: Tuple values containing domain and path
+    private static func getHostAndPath(_ trackingServer: String) -> (String, String) {
         var components = trackingServer.components(separatedBy: "/")
         let host = components.removeFirst()
         let path = components.isEmpty ? "" : "/" + components.joined(separator: "/")

--- a/AEPMedia/Sources/MediaCollection/MediaOfflineSession.swift
+++ b/AEPMedia/Sources/MediaCollection/MediaOfflineSession.swift
@@ -82,7 +82,7 @@ class MediaOfflineSession: MediaSession {
             return
         }
 
-        guard let url = MediaCollectionReportHelper.getTrackingURL(host: state.mediaCollectionServer ?? "") else {
+        guard let url = MediaCollectionReportHelper.getTrackingURL(trackingServer: state.mediaCollectionServer ?? "") else {
             Log.debug(label: Self.LOG_TAG, "[\(Self.CLASS_NAME)<\(#function)>] - [Session (\(id))] Exiting as it is not able to generate a valid URL.")
             return
         }

--- a/AEPMedia/Sources/MediaCollection/MediaRealTimeSession.swift
+++ b/AEPMedia/Sources/MediaCollection/MediaRealTimeSession.swift
@@ -165,9 +165,9 @@ class MediaRealTimeSession: MediaSession {
     private func generateHitUrl(_ isSessionStartHit: Bool) -> URL? {
         var url: URL?
         if isSessionStartHit {
-            url = MediaCollectionReportHelper.getTrackingURL(host: state.mediaCollectionServer ?? "")
+            url = MediaCollectionReportHelper.getTrackingURL(trackingServer: state.mediaCollectionServer ?? "")
         } else {
-            url = MediaCollectionReportHelper.getTrackingURLForEvents(host: state.mediaCollectionServer ?? "", sessionId: mcSessionId)
+            url = MediaCollectionReportHelper.getTrackingURLForEvents(trackingServer: state.mediaCollectionServer ?? "", sessionId: mcSessionId)
         }
         return url
     }

--- a/AEPMedia/Tests/UnitTests/MediaCollectionReportHelperTests.swift
+++ b/AEPMedia/Tests/UnitTests/MediaCollectionReportHelperTests.swift
@@ -29,11 +29,11 @@ class MediaCollectionReportHelperTests: XCTestCase {
 
     func testGetTrackingUrl_domainContainsValidPath() {
         // Setup
-        let host = "abc.com/va/"
+        let host = "abc.com/va"
         // Action
         let url = MediaCollectionReportHelper.getTrackingURL(trackingServer: host)
         // Assert
-        XCTAssertEqual(url, URL(string: "https://\(host)/api/v1/sessions"))
+        XCTAssertEqual(url, URL(string: "https://abc.com/va/api/v1/sessions"))
     }
 
     func testGetTrackingUrl_domainContainsInvalidPath() {
@@ -42,7 +42,7 @@ class MediaCollectionReportHelperTests: XCTestCase {
         // Action
         let url = MediaCollectionReportHelper.getTrackingURL(trackingServer: host)
         // Assert
-        XCTAssertEqual(url, URL(string: "https://\(host)/api/v1/sessions"))
+        XCTAssertEqual(url, URL(string: "https:////abc.com/va///api/v1/sessions"))
     }
 
     func testGetTrackingUrlForEvents() {

--- a/AEPMedia/Tests/UnitTests/MediaCollectionReportHelperTests.swift
+++ b/AEPMedia/Tests/UnitTests/MediaCollectionReportHelperTests.swift
@@ -22,7 +22,25 @@ class MediaCollectionReportHelperTests: XCTestCase {
         // Setup
         let host = "abc.com"
         // Action
-        let url = MediaCollectionReportHelper.getTrackingURL(host: host)
+        let url = MediaCollectionReportHelper.getTrackingURL(trackingServer: host)
+        // Assert
+        XCTAssertEqual(url, URL(string: "https://\(host)/api/v1/sessions"))
+    }
+
+    func testGetTrackingUrl_domainContainsValidPath() {
+        // Setup
+        let host = "abc.com/va/"
+        // Action
+        let url = MediaCollectionReportHelper.getTrackingURL(trackingServer: host)
+        // Assert
+        XCTAssertEqual(url, URL(string: "https://\(host)/api/v1/sessions"))
+    }
+
+    func testGetTrackingUrl_domainContainsInvalidPath() {
+        // Setup
+        let host = "//abc.com/va//"
+        // Action
+        let url = MediaCollectionReportHelper.getTrackingURL(trackingServer: host)
         // Assert
         XCTAssertEqual(url, URL(string: "https://\(host)/api/v1/sessions"))
     }
@@ -32,7 +50,7 @@ class MediaCollectionReportHelperTests: XCTestCase {
         let host = "abc.com"
         let sessionId = "sessionId"
         // Action
-        let url = MediaCollectionReportHelper.getTrackingURLForEvents(host: host, sessionId: sessionId)
+        let url = MediaCollectionReportHelper.getTrackingURLForEvents(trackingServer: host, sessionId: sessionId)
         // Assert
         XCTAssertEqual(url, URL(string: "https://\(host)/api/v1/sessions/\(sessionId)/events"))
     }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

Media backend required `/va` in the path in addition to `/api/v1/sessions` for the first party domain. 

URL for first party domains: `mydomain.com/va/api/v1/sessions`

URL for Adobe provisioned domains: `company.hb.omtrdc.net/api/v1/sessions`

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
